### PR TITLE
Github actions yaml, smaller de/ release file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: build
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dtolnay/rust-toolchain@nightly
+    - uses: awalsh128/cache-apt-pkgs-action@latest
+      with: {packages: libssh-dev, version: 1.0 }
+    - uses: actions/checkout@v3
+    - run: ./build.sh
+    - run: cd seed; cargo test --release; cd ..
+    - uses: actions/upload-artifact@v3.1.2
+      with: {name: de, path: de/target/release/de, if-no-files-found: error}

--- a/de/Cargo.toml
+++ b/de/Cargo.toml
@@ -3,6 +3,12 @@ edition = "2021"
 name = "de"
 version = "0.1.0"
 
+[profile.release]
+panic = "abort"
+strip = true
+opt-level = "z"
+codegen-units = 1
+
 [dependencies]
 anyhow = "1"
 clap = { version = "3.1", default-features = false, features = ["std"] }

--- a/seed/Cargo.toml
+++ b/seed/Cargo.toml
@@ -7,5 +7,3 @@ edition = "2021"
 panic = "abort"
 strip = true
 opt-level = "z"
-
-[dependencies]

--- a/seed/env_build.sh
+++ b/seed/env_build.sh
@@ -6,4 +6,4 @@
 # Adjust target-cpu to match you server. Find it like this:
 # `gcc -march=native -Q --help=target | grep march`
 
-export RUSTFLAGS="-Ctarget-cpu=core-avx2 -Clink-args=-nostartfiles -Crelocation-model=static -Clink-args=-Wl,-n,-N,--no-dynamic-linker,--no-pie,--build-id=none,--no-eh-frame-hdr"
+export RUSTFLAGS="-Ctarget-cpu=core-avx2 -Clink-args=-nostartfiles -Crelocation-model=static -Clink-args=-Wl,-n,-N,--no-dynamic-linker,--build-id=none,--no-eh-frame-hdr"


### PR DESCRIPTION
`--no-pie` is removed as some default linkers (e.g. Debian 11's ld) build without PIE by default and don't have this flag